### PR TITLE
Remotedbhostsupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,15 @@ Use this command to specify your own names, substituting `user_name`, `my_passwo
 ```
 bash bin/database.sh [-D, --domain] example.com [-U, --user] USER_NAME [-P, --password] MY_PASS [-DB, --database] DATABASE_NAME
 ```
+Additionally, if you want to use a RDS instance or an external database instance, you can skip this local database creation step altogether and configure the database properties only in the next section.
 ### Installing a WordPress Site
 To preconfigure the `wp-config` file, run the `database.sh` script for your domain, before you use the following command to install WordPress:
 ```
 ./bin/appinstall.sh [-A, --app] wordpress [-D, --domain] example.com
+```
+Additionally, if you want to install a wordpress configured for a remote database, remember to pass in the remote DB host details.
+```
+./bin/appinstall.sh [-A, --app] wordpress [-D, --domain] example.com [-R, --remote] test.uid.ap-south-1.rds.amazonaws.com
 ```
 ### Install ACME 
 We need to run the ACME installation command the **first time only**. 

--- a/bin/appinstall.sh
+++ b/bin/appinstall.sh
@@ -2,6 +2,7 @@
 APP_NAME=''
 DOMAIN=''
 EPACE='        '
+REMOTE_HOST=''
 
 echow(){
     FLAG=${1}
@@ -11,9 +12,11 @@ echow(){
 
 help_message(){
     echo -e "\033[1mOPTIONS\033[0m"
-    echow '-A, --app [app_name] -D, --domain [DOMAIN_NAME]'
+    echow '-A, --app [app_name] -D, --domain [DOMAIN_NAME] -R, --remote [REMOTE_HOST]'
     echo "${EPACE}${EPACE}Example: appinstall.sh -A wordpress -D example.com"
     echo "${EPACE}${EPACE}Will install WordPress CMS under the example.com domain"
+    echo "${EPACE}${EPACE}Example: appinstall.sh -A wordpress -D example.com -R test.uid.ap-south-1.rds.amazonaws.com"
+    echo "${EPACE}${EPACE}Will install WordPress CMS under the example.com domain with a remote host configuration"
     echow '-H, --help'
     echo "${EPACE}${EPACE}Display help and exit."
     exit 0
@@ -27,13 +30,13 @@ check_input(){
 }
 
 app_download(){
-    docker-compose exec litespeed su -c "appinstallctl.sh --app ${1} --domain ${2}"
+    docker-compose exec litespeed su -c "appinstallctl.sh --app ${1} --domain ${2} --remote ${3}"
     bash bin/webadmin.sh -r
     exit 0
 }
 
 main(){
-    app_download ${APP_NAME} ${DOMAIN}
+    app_download ${APP_NAME} ${DOMAIN} ${REMOTE_HOST}
 }
 
 check_input ${1}
@@ -49,7 +52,11 @@ while [ ! -z "${1}" ]; do
         -[dD] | -domain | --domain) shift
             check_input "${1}"
             DOMAIN="${1}"
-            ;;          
+            ;;
+        -[R] | -remote | --remote) shift
+            check_input "${1}"
+            REMOTE_HOST="${1}"
+            ;;	    
         *) 
             help_message
             ;;              

--- a/bin/container/appinstallctl.sh
+++ b/bin/container/appinstallctl.sh
@@ -3,7 +3,8 @@ DEFAULT_VH_ROOT='/var/www/vhosts'
 VH_DOC_ROOT=''
 VHNAME=''
 APP_NAME=''
-DOMAIN=''
+DOMAiIN=''
+REMOTE_HOST=''
 WWW_UID=''
 WWW_GID=''
 WP_CONST_CONF=''
@@ -95,7 +96,11 @@ set_vh_docroot(){
 check_sql_native(){
 	local COUNTER=0
 	local LIMIT_NUM=100
-	until [ "$(curl -v mysql:3306 2>&1 | grep -i 'native\|Connected')" ]; do
+	local TEST_HOST="mysql"
+	if [ ! -z "${REMOTE_HOST}" ]; then
+		TEST_HOST="${REMOTE_HOST}"
+	fi
+	until [ "$(curl -v "${TEST_HOST}":3306 2>&1 | grep -i 'native\|Connected')" ]; do
 		echo "Counter: ${COUNTER}/${LIMIT_NUM}"
 		COUNTER=$((COUNTER+1))
 		if [ ${COUNTER} = 10 ]; then
@@ -572,7 +577,6 @@ preinstall_wordpress(){
 		linechange 'DB_USER' ${VH_DOC_ROOT}/wp-config.php "${NEWDBPWD}"
 		NEWDBPWD="define('DB_NAME', '${SQL_DB}');"
 		linechange 'DB_NAME' ${VH_DOC_ROOT}/wp-config.php "${NEWDBPWD}"
-        #NEWDBPWD="define('DB_HOST', '${PUB_IP}');"
 		NEWDBPWD="define('DB_HOST', '${DB_HOST}');"
 		linechange 'DB_HOST' ${VH_DOC_ROOT}/wp-config.php "${NEWDBPWD}"
 	elif [ -f ${VH_DOC_ROOT}/wp-config.php ]; then
@@ -639,8 +643,12 @@ while [ ! -z "${1}" ]; do
 			;;
 		-vhname | --vhname) shift
 			VHNAME="${1}"
-			;;	       
-		*) 
+			;;
+		--remote) shift
+	                REMOTE_HOST="${1}"
+			DB_HOST="${1}"
+			;;		
+		*)
 			help_message
 			;;              
 	esac

--- a/bin/database.sh
+++ b/bin/database.sh
@@ -64,17 +64,17 @@ display_credential(){
 }
 
 store_credential(){
-    if [ -d "./sites/${1}" ]; then
-        if [ -f ./sites/${1}/.db_pass ]; then 
-            mv ./sites/${1}/.db_pass ./sites/${1}/.db_pass.bk
+    if [ -d "~/sites/${1}" ]; then
+        if [ -f ~/sites/${1}/.db_pass ]; then 
+            mv ~/sites/${1}/.db_pass ~/sites/${1}/.db_pass.bk
         fi
-        cat > "./sites/${1}/.db_pass" << EOT
+        cat > "~/sites/${1}/.db_pass" << EOT
 "Database":"${SQL_DB}"
 "Username":"${SQL_USER}"
 "Password":"$(echo ${SQL_PASS} | tr -d "'")"
 EOT
     else
-        echo "./sites/${1} not found, abort credential store!"
+        echo "~/sites/${1} not found, abort credential store!"
     fi    
 }
 

--- a/bin/database.sh
+++ b/bin/database.sh
@@ -64,17 +64,17 @@ display_credential(){
 }
 
 store_credential(){
-    if [ -d "~/sites/${1}" ]; then
-        if [ -f ~/sites/${1}/.db_pass ]; then 
-            mv ~/sites/${1}/.db_pass ~/sites/${1}/.db_pass.bk
+    if [ -d "$HOME/sites/${1}" ]; then
+        if [ -f $HOME/sites/${1}/.db_pass ]; then 
+            mv $HOME/sites/${1}/.db_pass $HOME/sites/${1}/.db_pass.bk
         fi
-        cat > "~/sites/${1}/.db_pass" << EOT
+        cat > "$HOME/sites/${1}/.db_pass" << EOT
 "Database":"${SQL_DB}"
 "Username":"${SQL_USER}"
 "Password":"$(echo ${SQL_PASS} | tr -d "'")"
 EOT
     else
-        echo "~/sites/${1} not found, abort credential store!"
+        echo "$HOME/sites/${1} not found, abort credential store!"
     fi    
 }
 

--- a/bin/database.sh
+++ b/bin/database.sh
@@ -8,6 +8,7 @@ SQL_PASS=''
 ANY="'%'"
 SET_OK=0
 EPACE='        '
+REMOTE_HOST=''
 
 echow(){
     FLAG=${1}
@@ -123,8 +124,20 @@ specify_setup_main(){
     store_credential ${DOMAIN}
 }
 
+specify_setup_remote(){
+    specify_name
+    check_input ${REMOTE_HOST}
+    db_setup
+    display_credential
+    store_credential ${DOMAIN}
+}
+
 main(){
-    if [ "${SQL_USER}" != '' ] && [ "${SQL_PASS}" != '' ] && [ "${SQL_DB}" != '' ]; then
+    if [ "${SQL_USER}" != '' ] && [ "${SQL_PASS}" != '' ] && [ "${SQL_DB}" != '' ] && [ "${REMOTE_HOST}" != ''  ]; then
+        specify_setup_remote
+    elif [ "${REMOTE_HOST}" != ''  ]; then
+	    printf "Please supply details in this format:\n\t database.sh -U user_name -P password -DB database -D domain -R remote_host \n"
+    elif [ "${SQL_USER}" != '' ] && [ "${SQL_PASS}" != '' ] && [ "${SQL_DB}" != '' ]; then
         specify_setup_main
     else
         auto_setup_main
@@ -148,8 +161,11 @@ while [ ! -z "${1}" ]; do
             ;;            
         -db | -DB | -database| --database) shift
             SQL_DB="${1}"
-            ;;            
-        *) 
+            ;;
+        -R | --remote) shift
+            REMOTE_HOST="${1}"
+	    ;;	    
+        *)
             help_message
             ;;              
     esac

--- a/bin/demosite.sh
+++ b/bin/demosite.sh
@@ -38,8 +38,8 @@ domain_filter(){
 }
 
 gen_root_fd(){
-    DOC_FD="./sites/${1}/"
-    if [ -d "./sites/${1}" ]; then
+    DOC_FD="~/sites/${1}/"
+    if [ -d "~/sites/${1}" ]; then
         echo -e "[O] The root folder \033[32m${DOC_FD}\033[0m exist."
     else
         echo "Creating - document root."

--- a/bin/demosite.sh
+++ b/bin/demosite.sh
@@ -38,8 +38,8 @@ domain_filter(){
 }
 
 gen_root_fd(){
-    DOC_FD="~/sites/${1}/"
-    if [ -d "~/sites/${1}" ]; then
+    DOC_FD="$HOME/sites/${1}/"
+    if [ -d "$HOME/sites/${1}" ]; then
         echo -e "[O] The root folder \033[32m${DOC_FD}\033[0m exist."
     else
         echo "Creating - document root."

--- a/bin/domain.sh
+++ b/bin/domain.sh
@@ -28,8 +28,8 @@ check_input(){
 add_domain(){
     check_input ${1}
     docker-compose exec ${CONT_NAME} su -s /bin/bash lsadm -c "cd /usr/local/lsws/conf && domainctl.sh --add ${1}"
-    if [ ! -d "~/sites/${1}" ]; then 
-        mkdir -p ~/sites/${1}/{html,logs,certs}
+    if [ ! -d "$HOME/sites/${1}" ]; then 
+        mkdir -p $HOME/sites/${1}/{html,logs,certs}
     fi
     bash bin/webadmin.sh -r
 }

--- a/bin/domain.sh
+++ b/bin/domain.sh
@@ -28,8 +28,8 @@ check_input(){
 add_domain(){
     check_input ${1}
     docker-compose exec ${CONT_NAME} su -s /bin/bash lsadm -c "cd /usr/local/lsws/conf && domainctl.sh --add ${1}"
-    if [ ! -d "./sites/${1}" ]; then 
-        mkdir -p ./sites/${1}/{html,logs,certs}
+    if [ ! -d "~/sites/${1}" ]; then 
+        mkdir -p ~/sites/${1}/{html,logs,certs}
     fi
     bash bin/webadmin.sh -r
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,10 +38,10 @@ services:
       TZ: ${TimeZone}
   # phpmyadmin
   phpmyadmin:
-    image: bitnami/phpmyadmin:5.0.2-debian-10-r72
+    image: phpmyadmin
     ports:
       - 8080:80
       - 8443:443
     environment:
-        DATABASE_HOST: mysql
+        - PMA_ARBITRARY=1
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 services:
+  # database
   mysql:
     image: mariadb:10.5.9
     command: --max_allowed_packet=256M
@@ -13,6 +14,7 @@ services:
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     restart: always
+  # web server
   litespeed:
     image: litespeedtech/openlitespeed:${OLS_VERSION}-${PHP_VERSION}
     env_file:
@@ -21,7 +23,9 @@ services:
         - ./lsws/conf:/usr/local/lsws/conf
         - ./lsws/admin-conf:/usr/local/lsws/admin/conf
         - ./bin/container:/usr/local/bin
-        - ./sites:/var/www/vhosts/
+        - type: bind
+          source: $HOME/sites
+          target: /var/www/vhosts/
         - ./acme:/root/.acme.sh/
         - ./logs:/usr/local/lsws/logs/
     ports:
@@ -32,6 +36,7 @@ services:
     restart: always
     environment:
       TZ: ${TimeZone}
+  # phpmyadmin
   phpmyadmin:
     image: bitnami/phpmyadmin:5.0.2-debian-10-r72
     ports:
@@ -39,4 +44,4 @@ services:
       - 8443:443
     environment:
         DATABASE_HOST: mysql
-    restart: always    
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,5 @@
 version: '3'
 services:
-  # database
-  mysql:
-    image: mariadb:10.5.9
-    command: --max_allowed_packet=256M
-    volumes:
-      - "./data/db:/var/lib/mysql:delegated"
-    ports:
-       - "3306:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-    restart: always
   # web server
   litespeed:
     image: litespeedtech/openlitespeed:${OLS_VERSION}-${PHP_VERSION}


### PR DESCRIPTION
added code changes for remote DB support.
Now, the user can specify a DB with the -R switch and it will setup to a  remote DB instance, for example, the RDS DB on aws.