### PR TITLE
Ensure that files have the correct character encoding.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+#
+# Configure line ending normalisation for this repository.
+# See http://schacon.github.io/git/gitattributes.html for more information.
+#
+# Also each developer should configure the old style normalisation on her workstation
+# (see http://timclem.wordpress.com/2012/03/01/mind-the-end-of-your-line/):
+#
+# Windows user should use: git config --global core.autocrlf = true
+# Unix/Linux users should use: git config --global core.autocrlf = input
+#
+
+# Auto detect text files and perform LF normalization
+*       text=auto
+
+*.txt   text
+*.xml   text diff=xml
+# Shell scripts require LF
+*.sh    text eol=lf
+# Batch scripts require CRLF
+*.bat   text eol=crlf


### PR DESCRIPTION
File downloaded on a windows host but are shell scripts must be checked out with CR, instead of LFCR