### PR TITLE
Don't publish MySQL port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     command: --max_allowed_packet=256M
     volumes:
       - "./data/db:/var/lib/mysql:delegated"
-    ports:
-       - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
@@ -22,12 +20,12 @@ services:
     env_file:
       - .env
     volumes:
-        - ./lsws/conf:/usr/local/lsws/conf
-        - ./lsws/admin-conf:/usr/local/lsws/admin/conf
-        - ./bin/container:/usr/local/bin
-        - ./sites:/var/www/vhosts/
-        - ./acme:/root/.acme.sh/
-        - ./logs:/usr/local/lsws/logs/
+      - ./lsws/conf:/usr/local/lsws/conf
+      - ./lsws/admin-conf:/usr/local/lsws/admin/conf
+      - ./bin/container:/usr/local/bin
+      - ./sites:/var/www/vhosts/
+      - ./acme:/root/.acme.sh/
+      - ./logs:/usr/local/lsws/logs/
     ports:
       - 80:80
       - 443:443
@@ -44,5 +42,5 @@ services:
       - 8080:80
       - 8443:443
     environment:
-        DATABASE_HOST: mysql
-    restart: always    
+      DATABASE_HOST: mysql
+    restart: always


### PR DESCRIPTION
Containers should be able to communicate between themselves without mapping the MySQL container's port to the host.

Security-wise, it's better to expose as little as possible.

Also cleaned some white space. 