### PR TITLE
Remove logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       - default
   litespeed:
     image: litespeedtech/openlitespeed:${OLS_VERSION}-${PHP_VERSION}
-    logging:
-      driver: none
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Remove logging to prevent `Error response from daemon: configured logging driver does not support reading` from being booted