### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - default
   litespeed:
     image: litespeedtech/openlitespeed:${OLS_VERSION}-${PHP_VERSION}
+    container_name: litespeed
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
In the /bin/webadmin.sh file, CONT_NAME='litespeed' is used to check if the Litespeed docker container is running.  https://github.com/litespeedtech/ols-docker-env/blob/d7b39ddeb46e454d413ce9e3fc80678384b0c8a2/bin/webadmin.sh#L2

Because the docker-compose file does not explicitly specify the container name for Litespeed, newcomers following the steps in the readme.md might encounter an error indicating that Litespeed is not running, which could be confusing. It is recommended to explicitly define a container name in the docker-compose example file that matches the hardcoded container name in the shell script.