### PR TITLE
Enable use of an existing MySQL server by simply setting MYSQL_HOST in the .env file.

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
-TimeZone=America/Boise
+TimeZone=America/New_York
 OLS_VERSION=1.8.1
 PHP_VERSION=lsphp83
-#Uncomment the following line to use existing Database host and skip the MySQL container creation
-#MYSQL_HOST=10.0.0.10
+#To use your database host, please uncomment the MYSQL_HOST line.
+#MYSQL_HOST=1.2.3.4
 MYSQL_DATABASE=wordpress
 MYSQL_ROOT_PASSWORD=password
 MYSQL_USER=wordpress

--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
-TimeZone=America/New_York
+TimeZone=America/Boise
 OLS_VERSION=1.8.1
 PHP_VERSION=lsphp83
+#Uncomment the following line to use existing Database host and skip the MySQL container creation
+#MYSQL_HOST=10.0.0.10
 MYSQL_DATABASE=wordpress
 MYSQL_ROOT_PASSWORD=password
 MYSQL_USER=wordpress

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install a lightweight WordPress container with OpenLiteSpeed Edge or Stable vers
 2. [Install Docker Compose](https://docs.docker.com/compose/)
 
 ## Configuration
-Edit the `.env` file to update the demo site domain, default MySQL user, and password.
+Edit the `.env` file to update the demo site domain, default MySQL user, and password and optionally set hostname for existing MySQL server.
 Feel free to check [Docker hub Tag page](https://hub.docker.com/repository/docker/litespeedtech/openlitespeed/tags) if you want to update default openlitespeed and php versions. 
 
 ## Installation
@@ -19,10 +19,19 @@ Clone this repository or copy the files from this repository into a new folder:
 ```
 git clone https://github.com/litespeedtech/ols-docker-env.git
 ```
+
 Open a terminal, `cd` to the folder in which `docker compose.yml` is saved, and run:
+# To use an existing MySQL server
 ```
-docker compose up
+docker compose up -d
 ```
+Note: Be sure to uncomment, and set MYSQL_HOST in the .env file
+
+# To use the included MySQL Server (as well as phpMyAdmin)
+```
+docker compose --profile database up -d
+```
+Note: Be sure MYSQL_HOST is commented out in the .env file
 
 Note: If you wish to run a single web server container, please see the [usage method here](https://github.com/litespeedtech/ols-dockerfiles#usage).
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ git clone https://github.com/litespeedtech/ols-docker-env.git
 ```
 
 Open a terminal, `cd` to the folder in which `docker compose.yml` is saved, and run:
-# To use an existing MySQL server
+### To use an existing MySQL server
 ```
 docker compose up -d
 ```
 Note: Be sure to uncomment, and set MYSQL_HOST in the .env file
 
-# To use the included MySQL Server (as well as phpMyAdmin)
+### To use the included MySQL Server (as well as phpMyAdmin)
 ```
 docker compose --profile database up -d
 ```

--- a/README.md
+++ b/README.md
@@ -19,21 +19,16 @@ Clone this repository or copy the files from this repository into a new folder:
 ```
 git clone https://github.com/litespeedtech/ols-docker-env.git
 ```
-
 Open a terminal, `cd` to the folder in which `docker compose.yml` is saved, and run:
-### To use an existing MySQL server
 ```
-docker compose up -d
+docker compose up
 ```
-Note: Be sure to uncomment, and set MYSQL_HOST in the .env file
-
-### To use the included MySQL Server (as well as phpMyAdmin)
-```
-docker compose --profile database up -d
-```
-Note: Be sure MYSQL_HOST is commented out in the .env file
 
 Note: If you wish to run a single web server container, please see the [usage method here](https://github.com/litespeedtech/ols-dockerfiles#usage).
+
+#### To use your own DataBase Server (including phpMyAdmin)
+1. Comment out MYSQL_HOST and update the IP in the .env file.
+2. Start containers with the command: `docker compose --profile database up -d`
 
 ## Components
 The docker image installs the following packages on your system:

--- a/bin/container/appinstallctl.sh
+++ b/bin/container/appinstallctl.sh
@@ -99,7 +99,7 @@ check_sql_native(){
 	else
 		get_db_pass ${DOMAIN}
 	fi
-	if [ "${DB_HOST}" == '' ] then
+	if [ "${DB_HOST}" == '' ]; then
 		local COUNTER=0
 		local LIMIT_NUM=100
 		until [ "$(curl -v mysql:3306 2>&1 | grep -i 'native\|Connected')" ]; do

--- a/bin/demosite.sh
+++ b/bin/demosite.sh
@@ -53,7 +53,7 @@ create_db(){
         echo "Parameters not supplied, please check!"
         exit 1
     else    
-        bash bin/database.sh -D ${1} -U ${MYSQL_USER} -P ${MYSQL_PASSWORD} -DB ${MYSQL_DATABASE}
+        bash bin/database.sh -D ${1} -H ${MYSQL_HOST} -U ${MYSQL_USER} -P ${MYSQL_PASSWORD} -DB ${MYSQL_DATABASE}
     fi    
 }    
 
@@ -63,6 +63,7 @@ store_credential(){
     else
         echo 'Storing database parameter'
         cat > "${DOC_FD}/.db_pass" << EOT
+"Host":"${MYSQL_HOST}"
 "Database":"${MYSQL_DATABASE}"
 "Username":"${MYSQL_USER}"
 "Password":"$(echo ${MYSQL_PASSWORD} | tr -d "'")"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   mysql:
     image: mariadb:10.5.9
+    profiles:
+      - database
     logging:
       driver: none
     command: ["--max-allowed-packet=512M"]
@@ -39,6 +41,8 @@ services:
       - default
   phpmyadmin:
     image: bitnami/phpmyadmin:5.2.0-debian-11-r43
+    profiles:
+      - database    
     ports:
       - 8080:8080
       - 8443:8443


### PR DESCRIPTION
Simply uncomment MYSQL_HOST in .env and set appropriately to use an existing MySQL server.

Additional change: By default, docker compose will NOT deploy the MySQL nor phpMyAdmin services (regardless of MYSQL_HOST setting. To deploy these the user must add '--profile database' to the docker compose command.

Documentation has been updated. 

I have done a full run-through and Wordpress fired right up. Also did a test without MYSQL_HOST set and with --profile database and got the stack running with the included MySQL/phpMyAdmin services.
