### PR TITLE
Fix critical db reference resulting in db scripts not working database.sh

### DIFF
--- a/bin/database.sh
+++ b/bin/database.sh
@@ -83,7 +83,7 @@ EOT
 }
 
 check_db_access(){
-    docker compose exec -T mysql su -c "mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} -e 'status'" >/dev/null 2>&1
+    docker compose exec -T mariadb su -c "mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} -e 'status'" >/dev/null 2>&1
     if [ ${?} != 0 ]; then
         echo '[X] DB access failed, please check!'
         exit 1
@@ -91,7 +91,7 @@ check_db_access(){
 }
 
 check_db_exist(){
-    docker compose exec -T mysql su -c "test -e /var/lib/mysql/${1}"
+    docker compose exec -T mariadb su -c "test -e /var/lib/mysql/${1}"
     if [ ${?} = 0 ]; then
         echo "Database ${1} already exist, skip DB creation!"
         exit 0    
@@ -99,7 +99,7 @@ check_db_exist(){
 }
 
 check_db_not_exist(){
-    docker compose exec -T mysql su -c "test -e /var/lib/mysql/${1}"
+    docker compose exec -T mariadb su -c "test -e /var/lib/mysql/${1}"
     if [ ${?} != 0 ]; then
         echo "Database ${1} doesn't exist, skip DB deletion!"
         exit 0
@@ -107,7 +107,7 @@ check_db_not_exist(){
 }
 
 db_setup(){  
-    docker compose exec -T mysql su -c 'mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} \
+    docker compose exec -T mariadb su -c 'mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} \
     -e "CREATE DATABASE '${SQL_DB}';" \
     -e "GRANT ALL PRIVILEGES ON '${SQL_DB}'.* TO '${SQL_USER}'@'${ANY}' IDENTIFIED BY '${SQL_PASS}';" \
     -e "FLUSH PRIVILEGES;"'
@@ -123,7 +123,7 @@ db_delete(){
         SQL_USER="${SQL_DB}"
     fi
     check_db_not_exist ${SQL_DB}
-    docker compose exec -T mysql su -c 'mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} \
+    docker compose exec -T mariadb su -c 'mariadb -uroot --password=${MYSQL_ROOT_PASSWORD} \
         -e "DROP DATABASE IF EXISTS '${SQL_DB}';" \
         -e "DROP USER IF EXISTS '${SQL_USER}'@'${ANY}';" \
         -e "FLUSH PRIVILEGES;"'


### PR DESCRIPTION
Fixed incorrect reference to db, resulting in scripts related to the db not working. Updated docker compose exec -T mysql to docker compose exec -T mariadb. Previous updates to docker-compose.yml, changing mysql to mariadb require this update for the script to function.