### PR TITLE
Update images to the latest versions. Coded default 1.8.5-lsphp85

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,22 @@
-TimeZone=America/New_York
-OLS_VERSION=1.8.5
-PHP_VERSION=lsphp85
-PHPMYADMIN_VERSION=5.2.3
-MYSQL_ROOT_PASSWORD=your_root_password
+# ========================================
+# PRODUCTION ENVIRONMENT (2GB+ Optimized) 
+# ========================================
+TIMEZONE=America/New_York
+MYSQL_ROOT_PASSWORD=your_super_secure_root_password_123
 MYSQL_DATABASE=wordpress
 MYSQL_USER=wordpress
-MYSQL_PASSWORD=your_password
+MYSQL_PASSWORD=your_secure_app_password_456
 DOMAIN=localhost
+
+# ========================================
+# HIGH MEMORY SERVERS (8GB+) - UNCOMMENT FOR 8GB+
+# ========================================
+# MARIADB_MAX_CONNS=400            # More concurrent requests
+
+# ========================================
+# IMAGE OVERRIDES (Optional)
+# ========================================
+# LITESPEED_IMAGE=1.8.5-lsphp85    # Default - Newest version as of 1/15/26(latest refelcts lsphp84)
+# LITESPEED_IMAGE=latest           # Use once latest reflects a newer version
+# MARIADB_IMAGE=mariadb:lts-noble
+# REDIS_IMAGE=redis:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - default
 
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:${PHPMYADMIN_IMAGE:-phpmyadmin:latest}
+    image: phpmyadmin/phpmyadmin:${PHPMYADMIN_IMAGE:-latest}
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     image: ${REDIS_IMAGE:-redis:alpine}
     logging:
       driver: none
-    # No command = maxmemory 0 (unbounded, your proven production default)
+    # command: redis-server --requirepass 8b405f60665e48f795752e534d93b722
     volumes:
       - ./redis/data:/data
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 services:
   mysql:
-    image: mariadb:11.4
+    image: ${MARIADB_IMAGE:-mariadb:lts-noble}
     logging:
       driver: none
-    command: ["--max-allowed-packet=512M"]
+    command:
+      - "--max-allowed-packet=512M"              # Original dev's proven value
+      - "--max-connections=${MARIADB_MAX_CONNS:-200}"  # 200 default, 400 for 8GB+
     volumes:
       - "./data/db:/var/lib/mysql:delegated"
     environment:
@@ -14,8 +16,9 @@ services:
     restart: always
     networks:
       - default
+
   litespeed:
-    image: litespeedtech/openlitespeed:${OLS_VERSION}-${PHP_VERSION}
+    image: litespeedtech/openlitespeed:${LITESPEED_IMAGE:-1.8.5-lsphp85}
     container_name: litespeed
     env_file:
       - .env
@@ -33,11 +36,12 @@ services:
       - 7080:7080
     restart: always
     environment:
-      TZ: ${TimeZone}
+      TZ: ${TIMEZONE}
     networks:
       - default
+
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:${PHPMYADMIN_VERSION}
+    image: phpmyadmin/phpmyadmin:${PHPMYADMIN_IMAGE:-phpmyadmin:latest}
     env_file:
       - .env
     ports:
@@ -47,11 +51,12 @@ services:
     restart: always
     networks:
       - default
+
   redis:
-    image: "redis:alpine"
+    image: ${REDIS_IMAGE:-redis:alpine}
     logging:
       driver: none
-    # command: redis-server --requirepass 8b405f60665e48f795752e534d93b722
+    # No command = maxmemory 0 (unbounded, your proven production default)
     volumes:
       - ./redis/data:/data
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
@@ -60,6 +65,7 @@ services:
     restart: always
     networks:
       - default
+
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
Update images to the latest versions. Hard Coded 1.8.5-lsphp85. Changed Mariadb max connections default to 200 and a variable for override.

#MARIADB_MAX_CONNS=400            # More concurrent requests
LITESPEED_IMAGE=1.8.5-lsphp85    # Default - Newest version as of 1/15/26(latest reflects lsphp84)
LITESPEED_IMAGE=latest           # Use once latest reflects a newer version
MARIADB_IMAGE=mariadb:lts-noble
REDIS_IMAGE=redis:alpine